### PR TITLE
Correcting variable to show block scope leak

### DIFF
--- a/democode/p02_scope.js
+++ b/democode/p02_scope.js
@@ -6,7 +6,7 @@ if (flag) {
 	let b= 2;
 }
 
-console.log(1)
+console.log(a)
 console.log(b)  // Will cause an error
 
 // no hoisting


### PR DESCRIPTION
I think you were trying to show that a is not block scoped and b was. Printing a number literal should always work.
